### PR TITLE
better method signature om VariableCombos

### DIFF
--- a/src/constraintsolver/VariableCombos.java
+++ b/src/constraintsolver/VariableCombos.java
@@ -30,19 +30,19 @@ public class VariableCombos<T extends Constraint, S> {
         return defaultAction();
     }
     
-    protected S variable_variable(Slot target, Slot decl, VariableSlot result, CombineConstraint constraint) {
+    protected S variable_variable(VariableSlot target, VariableSlot decl, VariableSlot result, CombineConstraint constraint) {
         return defaultAction();
     }
 
-    protected S constant_variable(Slot target, Slot decl, VariableSlot result, CombineConstraint constraint) {
+    protected S constant_variable(ConstantSlot target, VariableSlot decl, VariableSlot result, CombineConstraint constraint) {
         return defaultAction();
     }
 
-    protected S variable_constant(Slot target, Slot decl, VariableSlot result, CombineConstraint constraint) {
+    protected S variable_constant(VariableSlot target, ConstantSlot decl, VariableSlot result, CombineConstraint constraint) {
         return defaultAction();
     }
 
-    protected S constant_constant(Slot target, Slot decl, VariableSlot result, CombineConstraint constraint) {
+    protected S constant_constant(ConstantSlot target, ConstantSlot decl, VariableSlot result, CombineConstraint constraint) {
         return defaultAction();
     }
 


### PR DESCRIPTION
as the method name implies, we could use more accurate type in method signature to achieve better type safety, also saving the effort of force cast in subclass of `VariableCombos`.

e.g. change `constant_variable(Slot target, Slot decl, VariableSlot result, CombineConstraint constraint)` to `constant_variable(ConstantSlot target, VariableSlot decl, VariableSlot result, CombineConstraint constraint)`
